### PR TITLE
doc: Improve build instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,14 @@ A Python-based 3-D conceptual modeler allows for the implicit creation of comple
 Installing
 ----------
 
-Install the application
+Use Python 3.9.
+Note: It works also with gdal==3.4.1.
+
+Install the application.
 
 .. code-block:: console
 
+    pip install -r requirements.txt
     pip install -e .
 
 
@@ -22,7 +26,7 @@ Run the application
 
 .. code-block:: console
 
-    conceptual_modeler
+    conceptual-modeler
 
 Features
 --------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-trame>=2.0.0
+numpy==1.21.6
+matplotlib==3.5.3
+scipy==1.7.3
 pandas==1.3.4
 gempy==2.2.10
 pyvista==0.37.0
@@ -6,5 +8,6 @@ theano==1.0.4
 gdal==3.5.1
 PyQt5==5.15.7
 mpld3==0.5.8
-vtk>=9.1.0
+vtk==9.2.5
 pftools>=1.3.2
+trame>=2.0.0


### PR DESCRIPTION
On Windows the GDAL wheel can be downloaded here: https://www.lfd.uci.edu/~gohlke/pythonlibs/#gdal And call pip install -r requirements -f path/to/the/wheel.whl

On Ubuntu, libgdal-dev must be installed (apt-get) first.